### PR TITLE
feat: gate reasoning parsing by model

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -15,6 +15,16 @@ export const API_ENDPOINTS = {
   [AI_SERVICE_GEMINI]: "/v1beta/models/{model}:generateContent",
 };
 
+// Models that return additional reasoning data
+export const REASONING_MODELS = [
+  "o1",
+  "o3",
+  "o4",
+  "gpt-4.1",
+  "gpt-5",
+  "deepseek-r1",
+];
+
 export const ADD_COMMENT_BLOCK_COMMAND_ID = "add-comment-block";
 export const ADD_HR_COMMAND_ID = "add-hr";
 export const CALL_CHATGPT_API_COMMAND_ID = "call-chatgpt-api";

--- a/src/Services/AiService.ts
+++ b/src/Services/AiService.ts
@@ -12,6 +12,7 @@ import {
   AI_SERVICE_OPENAI,
   AI_SERVICE_OPENROUTER,
   API_ENDPOINTS,
+  REASONING_MODELS,
   NEWLINE,
   ROLE_USER,
   TITLE_INFERENCE_ERROR_HEADER,
@@ -148,6 +149,15 @@ export abstract class BaseAiService implements IAiApiService {
     if (settings) {
       config.url = url;
     }
+
+    const modelName = config.model?.includes("@")
+      ? config.model.split("@")[1]
+      : config.model;
+    const supportsReasoning = REASONING_MODELS.some((prefix) =>
+      modelName?.startsWith(prefix)
+    );
+    this.apiResponseParser.setSupportsReasoning(supportsReasoning);
+    this.apiService.setSupportsReasoning(supportsReasoning);
 
     return options.stream && editor
       ? this.callStreamingAPI(apiKey, messages, config, editor, headingPrefix, setAtCursor, settings)

--- a/src/Services/ApiResponseParser.ts
+++ b/src/Services/ApiResponseParser.ts
@@ -42,6 +42,7 @@ export class ApiResponseParser {
   private notificationService: NotificationService;
   private collectedCitations: Set<string> = new Set();
   private collectedReasoning: string[] = [];
+  private supportsReasoning: boolean = true;
 
   // Table buffering properties
   private tableBuffer: string = "";
@@ -50,6 +51,10 @@ export class ApiResponseParser {
 
   constructor(notificationService?: NotificationService) {
     this.notificationService = notificationService || new NotificationService();
+  }
+
+  setSupportsReasoning(value: boolean): void {
+    this.supportsReasoning = value;
   }
 
   /**
@@ -272,11 +277,11 @@ export class ApiResponseParser {
         try {
           const json = JSON.parse(payloadString);
 
-          if (json.reasoning) {
+          if (this.supportsReasoning && json.reasoning) {
             this.collectedReasoning.push(json.reasoning);
           }
 
-          if (json.delta?.reasoning) {
+          if (this.supportsReasoning && json.delta?.reasoning) {
             this.collectedReasoning.push(json.delta.reasoning);
           }
 
@@ -331,7 +336,7 @@ export class ApiResponseParser {
         }
       }
 
-      if (json.reasoning) {
+      if (this.supportsReasoning && json.reasoning) {
         this.collectedReasoning.push(json.reasoning);
       }
 
@@ -343,7 +348,7 @@ export class ApiResponseParser {
           for (const choice of finishedChoices) {
             const reasoning =
               choice.reasoning || choice.message?.reasoning || null;
-            if (reasoning) {
+            if (this.supportsReasoning && reasoning) {
               this.collectedReasoning.push(reasoning);
             }
           }
@@ -386,11 +391,11 @@ export class ApiResponseParser {
     try {
       const json = JSON.parse(line);
 
-      if (json.reasoning) {
+      if (this.supportsReasoning && json.reasoning) {
         this.collectedReasoning.push(json.reasoning);
       }
 
-      if (json.message?.reasoning) {
+      if (this.supportsReasoning && json.message?.reasoning) {
         this.collectedReasoning.push(json.message.reasoning);
       }
 
@@ -439,14 +444,14 @@ export class ApiResponseParser {
 
       const json = JSON.parse(payloadString);
 
-      if (json.reasoning) {
+      if (this.supportsReasoning && json.reasoning) {
         this.collectedReasoning.push(json.reasoning);
       }
 
       // Handle Gemini's streaming response format
       if (json.candidates && json.candidates.length > 0) {
         const candidate = json.candidates[0];
-        if (candidate.reasoning) {
+        if (this.supportsReasoning && candidate.reasoning) {
           this.collectedReasoning.push(candidate.reasoning);
         }
         if (candidate.content && candidate.content.parts && candidate.content.parts.length > 0) {
@@ -560,7 +565,7 @@ export class ApiResponseParser {
       text += "\n```";
     }
 
-    if (this.collectedReasoning.length > 0) {
+    if (this.supportsReasoning && this.collectedReasoning.length > 0) {
       const reasoningText = this.collectedReasoning.join("\n\n");
       const inserted = appendReasoningBlockquote(editor, reasoningText, setAtCursor);
       text += inserted;

--- a/src/Services/ApiService.ts
+++ b/src/Services/ApiService.ts
@@ -28,6 +28,10 @@ export class ApiService {
     this.apiResponseParser = apiResponseParser || new ApiResponseParser();
   }
 
+  setSupportsReasoning(value: boolean): void {
+    this.apiResponseParser.setSupportsReasoning(value);
+  }
+
   /**
    * Make a streaming API request
    * @param url The API endpoint URL


### PR DESCRIPTION
## Summary
- list reasoning-capable model prefixes in constants
- detect reasoning support in AiService and configure parsers accordingly
- skip reasoning extraction when model lacks support

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be161f41f4832d98e810acb6bd4f35