### PR TITLE
feat: add reasoning visibility toggle

### DIFF
--- a/src/Models/Config.ts
+++ b/src/Models/Config.ts
@@ -60,6 +60,8 @@ export interface ChatBehaviorSettings {
   generateAtCursor: boolean;
   /** Whether to automatically infer title after 4 messages have been exchanged */
   autoInferTitle: boolean;
+  /** Whether to append model reasoning after responses */
+  showReasoning: boolean;
   /** System message that provides context about the Obsidian/ChatGPT MD plugin environment */
   pluginSystemMessage: string;
 }
@@ -206,6 +208,7 @@ export const DEFAULT_SETTINGS: ChatGPT_MDSettings = {
   stream: true,
   generateAtCursor: false,
   autoInferTitle: false,
+  showReasoning: true,
   pluginSystemMessage: PLUGIN_SYSTEM_MESSAGE,
 
   // Formatting

--- a/src/Services/AiService.ts
+++ b/src/Services/AiService.ts
@@ -153,9 +153,9 @@ export abstract class BaseAiService implements IAiApiService {
     const modelName = config.model?.includes("@")
       ? config.model.split("@")[1]
       : config.model;
-    const supportsReasoning = REASONING_MODELS.some((prefix) =>
-      modelName?.startsWith(prefix)
-    );
+    const supportsReasoning =
+      Boolean(settings?.showReasoning) &&
+      REASONING_MODELS.some((prefix) => modelName?.startsWith(prefix));
     this.apiResponseParser.setSupportsReasoning(supportsReasoning);
     this.apiService.setSupportsReasoning(supportsReasoning);
 

--- a/src/Views/ChatGPT_MDSettingsTab.ts
+++ b/src/Views/ChatGPT_MDSettingsTab.ts
@@ -111,6 +111,13 @@ export class ChatGPT_MDSettingsTab extends PluginSettingTab {
         group: "Chat Behavior",
       },
       {
+        id: "showReasoning",
+        name: "Show reasoning",
+        description: "Append reasoning after responses when supported",
+        type: "toggle",
+        group: "Chat Behavior",
+      },
+      {
         id: "inferTitleLanguage",
         name: "Infer Title Language",
         description: "Language to use for title inference.",


### PR DESCRIPTION
## Summary
- add `showReasoning` option to configuration and defaults
- expose "Show reasoning" toggle in Chat Behavior settings
- honor user preference when appending reasoning to responses

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be17a4f974832dad922acb446d5221