### PR TITLE
feat: add reasoning toggle to frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ max_tokens: 300
 presence_penalty: 0.5
 frequency_penalty: 0.5
 stream: true
+reasoning: true
 stop: null
 n: 1
 model: gpt-5-mini
@@ -131,6 +132,7 @@ openaiUrl: https://api.openai.com
 # ollamaUrl: http://localhost:11434
 ---
 ```
+Use `reasoning: true` to include model reasoning in responses when supported.
 💡 Pro tip: Increasing `max_tokens` to a higher value e.g. `4096` for more complex tasks like reasoning, coding or text creation.
 The default model `gpt-5-mini` is optimized for speed and efficiency. Upgrade to `gpt-5` for enhanced reasoning capabilities or use `gpt-5-nano` for ultra-lightweight responses.
 

--- a/src/Models/Config.ts
+++ b/src/Models/Config.ts
@@ -22,6 +22,7 @@ max_tokens: ${DEFAULT_OPENAI_CONFIG.max_tokens}
 model: ${DEFAULT_OPENAI_CONFIG.model}
 presence_penalty: ${DEFAULT_OPENAI_CONFIG.presence_penalty}
 stream: true
+reasoning: true
 temperature: ${DEFAULT_OPENAI_CONFIG.temperature}
 ---`;
 };

--- a/src/Services/AiService.ts
+++ b/src/Services/AiService.ts
@@ -153,8 +153,10 @@ export abstract class BaseAiService implements IAiApiService {
     const modelName = config.model?.includes("@")
       ? config.model.split("@")[1]
       : config.model;
+    const reasoningPreference =
+      options.reasoning !== undefined ? options.reasoning : settings?.showReasoning;
     const supportsReasoning =
-      Boolean(settings?.showReasoning) &&
+      Boolean(reasoningPreference) &&
       REASONING_MODELS.some((prefix) => modelName?.startsWith(prefix));
     this.apiResponseParser.setSupportsReasoning(supportsReasoning);
     this.apiService.setSupportsReasoning(supportsReasoning);

--- a/src/Services/FrontmatterService.ts
+++ b/src/Services/FrontmatterService.ts
@@ -46,10 +46,8 @@ export class FrontmatterService {
       ? parseSettingsFrontmatter(settings.defaultChatFrontmatter)
       : {};
 
-    // Merge configurations with proper priority order
-    const mergedConfig = { ...settings, ...defaultFrontmatter, ...frontmatter } as Record<string, any>;
-
     // Determine AI service
+    const mergedConfig = { ...settings, ...defaultFrontmatter, ...frontmatter } as Record<string, any>;
     const aiService =
       mergedConfig.aiService ||
       aiProviderFromUrl(mergedConfig.url, mergedConfig.model) ||
@@ -67,6 +65,11 @@ export class FrontmatterService {
     };
     const defaultConfig = serviceDefaults[aiService] || DEFAULT_OPENAI_CONFIG;
 
+    const reasoningValue =
+      frontmatter.reasoning ??
+      defaultFrontmatter.reasoning ??
+      settings.showReasoning;
+
     // Return final configuration with everything merged
     return {
       ...defaultConfig,
@@ -74,6 +77,8 @@ export class FrontmatterService {
       ...defaultFrontmatter,
       ...frontmatter,
       aiService,
+      reasoning: reasoningValue,
+      showReasoning: reasoningValue,
     };
   }
 
@@ -116,6 +121,9 @@ export class FrontmatterService {
       if (typeof value === "string") {
         return `${key}: "${value}"`;
       }
+      if (typeof value === "boolean") {
+        return `${key}: ${value}`;
+      }
       return `${key}: ${value}`;
     });
 
@@ -147,6 +155,7 @@ export class FrontmatterService {
     // Start with basic settings
     let frontmatterObj: Record<string, any> = {
       stream: settings.stream,
+      reasoning: settings.showReasoning,
       ...additionalSettings,
     };
 


### PR DESCRIPTION
## Summary
- support `reasoning` boolean in generated frontmatter and YAML conversion
- merge global and per-file reasoning preference with per-file override
- document `reasoning: true|false` in default frontmatter template and README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be19b2f018832d9e7af2f38cce51a1