### PR TITLE
Expose reasoning data from API responses

### DIFF
--- a/src/Services/AnthropicService.ts
+++ b/src/Services/AnthropicService.ts
@@ -187,10 +187,20 @@ export class AnthropicService extends BaseAiService implements IAiApiService {
     editor: Editor,
     headingPrefix: string,
     setAtCursor?: boolean | undefined,
-    settings?: ChatGPT_MDSettings
+    settings?: ChatGPT_MDSettings,
+    supportsReasoning?: boolean
   ): Promise<{ fullString: string; mode: "streaming"; wasAborted?: boolean }> {
     // Use the default implementation from BaseAiService
-    return this.defaultCallStreamingAPI(apiKey, messages, config, editor, headingPrefix, setAtCursor, settings);
+    return this.defaultCallStreamingAPI(
+      apiKey,
+      messages,
+      config,
+      editor,
+      headingPrefix,
+      setAtCursor,
+      settings,
+      supportsReasoning || false
+    );
   }
 
   protected async callNonStreamingAPI(

--- a/src/Services/ApiService.ts
+++ b/src/Services/ApiService.ts
@@ -85,7 +85,7 @@ export class ApiService {
     payload: any,
     headers: Record<string, string>,
     serviceType: string
-  ): Promise<any> {
+  ): Promise<{ text: string; reasoning?: string }> {
     try {
       console.log(`[ChatGPT MD] Making non-streaming request to ${serviceType}`, payload);
 
@@ -101,20 +101,22 @@ export class ApiService {
       const data = responseUrl.json;
 
       if (data?.error) {
-        return this.errorService.handleApiError({ error: data.error }, serviceType, {
+        const errorText = this.errorService.handleApiError({ error: data.error }, serviceType, {
           returnForChat: true,
           showNotification: true,
           context: { model: payload.model, url },
         });
+        return { text: errorText };
       }
 
       return this.apiResponseParser.parseNonStreamingResponse(data, serviceType);
     } catch (error) {
-      return this.errorService.handleApiError(error, serviceType, {
+      const errorText = this.errorService.handleApiError(error, serviceType, {
         returnForChat: true,
         showNotification: true,
         context: { model: payload.model, url },
       });
+      return { text: errorText };
     }
   }
 

--- a/src/Services/LmStudioService.ts
+++ b/src/Services/LmStudioService.ts
@@ -149,10 +149,20 @@ export class LmStudioService extends BaseAiService implements IAiApiService {
     editor: Editor,
     headingPrefix: string,
     setAtCursor?: boolean | undefined,
-    settings?: ChatGPT_MDSettings
+    settings?: ChatGPT_MDSettings,
+    supportsReasoning?: boolean
   ): Promise<{ fullString: string; mode: "streaming"; wasAborted?: boolean }> {
     // Use the default implementation from BaseAiService
-    return this.defaultCallStreamingAPI(apiKey, messages, config, editor, headingPrefix, setAtCursor, settings);
+    return this.defaultCallStreamingAPI(
+      apiKey,
+      messages,
+      config,
+      editor,
+      headingPrefix,
+      setAtCursor,
+      settings,
+      supportsReasoning || false
+    );
   }
 
   protected async callNonStreamingAPI(

--- a/src/Services/OllamaService.ts
+++ b/src/Services/OllamaService.ts
@@ -137,10 +137,20 @@ export class OllamaService extends BaseAiService implements IAiApiService {
     editor: Editor,
     headingPrefix: string,
     setAtCursor?: boolean | undefined,
-    settings?: ChatGPT_MDSettings
+    settings?: ChatGPT_MDSettings,
+    supportsReasoning?: boolean
   ): Promise<StreamingResponse> {
     // Use the default implementation from BaseAiService
-    return this.defaultCallStreamingAPI(apiKey, messages, config, editor, headingPrefix, setAtCursor, settings);
+    return this.defaultCallStreamingAPI(
+      apiKey,
+      messages,
+      config,
+      editor,
+      headingPrefix,
+      setAtCursor,
+      settings,
+      supportsReasoning || false
+    );
   }
 
   protected async callNonStreamingAPI(

--- a/src/Services/OpenAiService.ts
+++ b/src/Services/OpenAiService.ts
@@ -168,10 +168,20 @@ export class OpenAiService extends BaseAiService implements IAiApiService {
     editor: Editor,
     headingPrefix: string,
     setAtCursor?: boolean | undefined,
-    settings?: ChatGPT_MDSettings
+    settings?: ChatGPT_MDSettings,
+    supportsReasoning?: boolean
   ): Promise<{ fullString: string; mode: "streaming"; wasAborted?: boolean }> {
     // Use the default implementation from BaseAiService
-    return this.defaultCallStreamingAPI(apiKey, messages, config, editor, headingPrefix, setAtCursor, settings);
+    return this.defaultCallStreamingAPI(
+      apiKey,
+      messages,
+      config,
+      editor,
+      headingPrefix,
+      setAtCursor,
+      settings,
+      supportsReasoning || false
+    );
   }
 
   protected async callNonStreamingAPI(

--- a/src/Services/OpenRouterService.ts
+++ b/src/Services/OpenRouterService.ts
@@ -183,10 +183,20 @@ export class OpenRouterService extends BaseAiService implements IAiApiService {
     editor: Editor,
     headingPrefix: string,
     setAtCursor?: boolean | undefined,
-    settings?: ChatGPT_MDSettings
+    settings?: ChatGPT_MDSettings,
+    supportsReasoning?: boolean
   ): Promise<StreamingResponse> {
     // Use the default implementation from BaseAiService
-    return this.defaultCallStreamingAPI(apiKey, messages, config, editor, headingPrefix, setAtCursor, settings);
+    return this.defaultCallStreamingAPI(
+      apiKey,
+      messages,
+      config,
+      editor,
+      headingPrefix,
+      setAtCursor,
+      settings,
+      supportsReasoning || false
+    );
   }
 
   protected async callNonStreamingAPI(


### PR DESCRIPTION
## Summary
- Pass `supportsReasoning` to stream parser and collect reasoning data during streaming
- Surface reasoning in non-streaming responses for blockquote rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be1c163510832d992c19ed4b14decd