### PR TITLE
feat: add cursor-aware reasoning blockquote

### DIFF
--- a/src/Services/AiService.ts
+++ b/src/Services/AiService.ts
@@ -526,7 +526,12 @@ export abstract class BaseAiService implements IAiApiService {
       );
 
       if (supportsReasoning && result.reasoning) {
-        const inserted = appendReasoningBlockquote(editor, result.reasoning, setAtCursor);
+        const inserted = appendReasoningBlockquote(
+          editor,
+          result.reasoning,
+          cursorPositions,
+          setAtCursor
+        );
         result.text += inserted;
       }
 

--- a/src/Services/ApiResponseParser.ts
+++ b/src/Services/ApiResponseParser.ts
@@ -17,9 +17,19 @@ import { ApiService } from "./ApiService";
 export function appendReasoningBlockquote(
   editor: Editor,
   text: string,
+  cursorPositions: {
+    initialCursor: { line: number; ch: number };
+    newCursor: { line: number; ch: number };
+  },
   setAtCursor?: boolean
 ): string {
   const blockquote = "\n> " + text.trim().replace(/\n/g, "\n> ");
+  // Avoid manipulating text when there's an active selection
+  const selection = editor.getSelection();
+  if (selection && selection.length > 0) {
+    editor.setCursor(cursorPositions.newCursor);
+  }
+
   if (setAtCursor) {
     editor.replaceSelection(blockquote);
   } else {

--- a/src/Services/GeminiService.ts
+++ b/src/Services/GeminiService.ts
@@ -217,7 +217,12 @@ export class GeminiService extends BaseAiService implements IAiApiService {
       );
 
       if (supportsReasoning && result.reasoning) {
-        const inserted = appendReasoningBlockquote(editor, result.reasoning, setAtCursor);
+        const inserted = appendReasoningBlockquote(
+          editor,
+          result.reasoning,
+          cursorPositions,
+          setAtCursor
+        );
         result.text += inserted;
       }
 


### PR DESCRIPTION
## Summary
- add cursor-aware reasoning blockquote helper that preserves selections
- use helper in AI and Gemini services when adding reasoning

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beddad1760832db40d717651b466d3