### PR TITLE
feat: add reasoning debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ presence_penalty: 0.5
 frequency_penalty: 0.5
 stream: true
 reasoning: true
+debugReasoning: false
 stop: null
 n: 1
 model: gpt-5-mini
@@ -133,6 +134,7 @@ openaiUrl: https://api.openai.com
 ---
 ```
 Use `reasoning: true` to include model reasoning in responses when supported.
+Set `debugReasoning: true` to log reasoning chunks to the developer console.
 💡 Pro tip: Increasing `max_tokens` to a higher value e.g. `4096` for more complex tasks like reasoning, coding or text creation.
 The default model `gpt-5-mini` is optimized for speed and efficiency. Upgrade to `gpt-5` for enhanced reasoning capabilities or use `gpt-5-nano` for ultra-lightweight responses.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "yarn:build:full-analysis": "yarn build && yarn analyze",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
+    "test:debug-reasoning": "node scripts/test-debug-reasoning.mjs",
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "update-version": "node update-version.mjs"
   },

--- a/scripts/test-debug-reasoning.mjs
+++ b/scripts/test-debug-reasoning.mjs
@@ -1,0 +1,52 @@
+import { ReadableStream } from "node:stream/web";
+
+const debugReasoning = true;
+
+const lines = [
+  'data: {"choices":[{"delta":{"content":"Hello ","reasoning":"step 1"}}]}',
+  'data: {"choices":[{"delta":{"content":"world!","reasoning":"step 2"}}]}',
+  'data: [DONE]',
+];
+
+const stream = new ReadableStream({
+  start(controller) {
+    for (const line of lines) {
+      controller.enqueue(new TextEncoder().encode(line + "\n"));
+    }
+    controller.close();
+  },
+});
+
+async function run() {
+  const response = new Response(stream);
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  const reasoningChunks = [];
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value);
+    const parts = chunk.trim().split(/\n+/);
+    for (const part of parts) {
+      if (part.startsWith('data: [DONE]')) continue;
+      if (part.startsWith('data:')) {
+        const json = JSON.parse(part.substring(6));
+        const delta = json.choices?.[0]?.delta || {};
+        if (delta.content) text += delta.content;
+        if (delta.reasoning) {
+          reasoningChunks.push(delta.reasoning);
+          if (debugReasoning) {
+            console.log('[reasoning chunk]', delta.reasoning);
+          }
+        }
+      }
+    }
+  }
+
+  console.log('Response:', text);
+  console.log('Reasoning:', reasoningChunks.join('\n'));
+}
+
+run();

--- a/src/Services/AiService.ts
+++ b/src/Services/AiService.ts
@@ -160,6 +160,8 @@ export abstract class BaseAiService implements IAiApiService {
       REASONING_MODELS.some((prefix) => modelName?.startsWith(prefix));
     this.apiResponseParser.setSupportsReasoning(supportsReasoning);
     this.apiService.setSupportsReasoning(supportsReasoning);
+    const debugReasoning = Boolean(options.debugReasoning);
+    this.apiResponseParser.setDebugReasoning(debugReasoning);
 
     return options.stream && editor
       ? this.callStreamingAPI(

--- a/src/Services/FrontmatterService.ts
+++ b/src/Services/FrontmatterService.ts
@@ -69,6 +69,10 @@ export class FrontmatterService {
       frontmatter.reasoning ??
       defaultFrontmatter.reasoning ??
       settings.showReasoning;
+    const debugReasoningValue =
+      frontmatter.debugReasoning ??
+      defaultFrontmatter.debugReasoning ??
+      false;
 
     // Return final configuration with everything merged
     return {
@@ -79,6 +83,7 @@ export class FrontmatterService {
       aiService,
       reasoning: reasoningValue,
       showReasoning: reasoningValue,
+      debugReasoning: debugReasoningValue,
     };
   }
 
@@ -156,6 +161,7 @@ export class FrontmatterService {
     let frontmatterObj: Record<string, any> = {
       stream: settings.stream,
       reasoning: settings.showReasoning,
+      debugReasoning: false,
       ...additionalSettings,
     };
 


### PR DESCRIPTION
## Summary
- add `debugReasoning` flag to log reasoning chunks during streaming
- parse `debugReasoning` from frontmatter and wire through services
- document debug option and add sample debugging script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run test:debug-reasoning`


------
https://chatgpt.com/codex/tasks/task_e_68bee8ff3560832d8fb8da828d0dd962